### PR TITLE
[ISSUE-19] Change default landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Then run the full project
 $ docker-compose up
 ```
 
+The app is then available at the URL `http://localhost:3000`.
+
 ### Database initialization
 
 ```
@@ -62,6 +64,8 @@ $ cd turbo-potato/
 $ touch .env
 $ echo "RABBITMQ_URL='amqp://172.17.0.1:5672'" >> .env
 ```
+
+The RabbitMQ admin interface is avaialable at `http://localhost:15672`.
 
 ## Testing
 Launch the entire test suite (with RSpec):

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
+  # Starts the app on the rides list
+  root 'rides#index'
+
   resources :rides do
     put 'start_ride', to: 'rides#start_ride'
     put 'cancel_ride', to: 'rides#cancel_ride'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
+ Change the default landing page to `rides#index` page.
+ Update documentation in the README.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #19 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The project was previously landing on a default rails page instead of the rides list.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
